### PR TITLE
fix: allow deleting any gem line, not just last

### DIFF
--- a/app/lib/pages/edit_gem/logic/gem_edit_cubit.dart
+++ b/app/lib/pages/edit_gem/logic/gem_edit_cubit.dart
@@ -78,9 +78,9 @@ class CGemEditCubit extends Cubit<CGemEditState> {
     emit(CGemEditState(gem: state.gem, deletedLines: state.deletedLines));
   }
 
-  /// Deletes the last line of the gem.
-  void deleteLastLine() {
-    final deletedLine = state.gem.lines.removeLast();
+  /// Deletes the line at the given [index].
+  void deleteLine(int index) {
+    final deletedLine = state.gem.lines.removeAt(index);
 
     if (deletedLine.id != null) state.deletedLines.add(deletedLine);
 

--- a/app/lib/pages/edit_gem/page.dart
+++ b/app/lib/pages/edit_gem/page.dart
@@ -63,7 +63,7 @@ class CEditGemPage extends StatelessWidget implements AutoRouteWrapper {
   }
 
   void _onLineDeletePressed(BuildContext context, int index) =>
-      context.read<CGemEditCubit>().deleteLastLine();
+      context.read<CGemEditCubit>().deleteLine(index);
 
   void _onSaved(BuildContext context, String gemID) {
     if (initialGem == null) {
@@ -109,7 +109,7 @@ class CEditGemPage extends StatelessWidget implements AutoRouteWrapper {
                   line: state.gem.lines[index],
                   people: people,
                   occurredAt: state.gem.occurredAt,
-                  isDeleteEnabled: index == state.gem.lines.length - 1,
+                  isDeleteEnabled: state.gem.lines.length > 1,
                   isAnimated: false,
                   onPressed: () => _onLinePressed(context, state.gem, index),
                   onDeletePressed: () => _onLineDeletePressed(context, index),

--- a/hobnob.yml
+++ b/hobnob.yml
@@ -10,7 +10,7 @@ tasks:
       - call: dart:setup
       - call: dart:analyze
       - call: dart:test
-      # - call: db:test
+      - call: db:test
       - call: dart:build
       - call: website:update
 

--- a/hobnobs/database.yml
+++ b/hobnobs/database.yml
@@ -12,6 +12,7 @@ tasks:
   test:
     info: Run tests against the local Supabase database.
     steps:
+      - call: start
       - run: supabase db test
 
   reset:

--- a/packages/data/database_client/lib/src/gem_client.dart
+++ b/packages/data/database_client/lib/src/gem_client.dart
@@ -93,66 +93,31 @@ class CGemClient {
     required CGemsTableUpsert gem,
     required List<BigInt> deletedLineIDs,
     required List<CLinesTableInsert> lines,
-  }) =>
-      BobsJob.attempt(
-            run: () => gemsTable.upsertAndFetchValue(
-              upserts: [gem],
-              column: CGemsTable.id,
-            ),
-            onError: CRawGemSaveException.fromError,
-          )
-          .thenAttempt(
-            run: (gemID) async {
-              await linesTable.delete(
-                filter: CLinesTable.id.includedIn(deletedLineIDs),
-                modifier: linesTable.none(),
-              );
-              return gemID;
-            },
-            onError: CRawGemSaveException.fromError,
-          )
-          .thenAttempt(
-            run: (gemID) async {
-              await linesTable.insert(
-                inserts: lines
-                    .where((line) => line.id == null)
-                    .map(
-                      (line) => CLinesTableInsert(
-                        id: line.id,
-                        gemID: gemID,
-                        chestID: gem.chestID,
-                        text: line.text,
-                        personID: line.personID,
-                      ),
-                    )
-                    .toList(),
-                modifier: linesTable.none(),
-              );
-              return gemID;
-            },
-            onError: CRawGemSaveException.fromError,
-          )
-          .thenAttempt(
-            run: (gemID) async {
-              await linesTable.upsert(
-                upserts: lines
-                    .where((line) => line.id != null)
-                    .map(
-                      (line) => CLinesTableInsert(
-                        id: line.id,
-                        gemID: gemID,
-                        chestID: gem.chestID,
-                        text: line.text,
-                        personID: line.personID,
-                      ),
-                    )
-                    .toList(),
-                modifier: linesTable.none(),
-              );
-              return gemID;
-            },
-            onError: CRawGemSaveException.fromError,
-          );
+  }) => BobsJob.attempt(
+    run: () async {
+      final response = await supabaseClient.rpc<String>(
+        'save_gem',
+        params: {
+          'gem_id_param': gem.id,
+          'occurred_at_param': gem.occurredAt.toIso8601String(),
+          'chest_id_param': gem.chestID,
+          'deleted_line_ids_param':
+              deletedLineIDs.map((id) => id.toString()).toList(),
+          'lines_param': lines
+              .map(
+                (line) => {
+                  'id': line.id?.toString(),
+                  'text': line.text,
+                  'person_id': line.personID?.value?.toString(),
+                },
+              )
+              .toList(),
+        },
+      );
+      return response;
+    },
+    onError: CRawGemSaveException.fromError,
+  );
 
   /// Fetches the `limit` gem IDs by random for the given `chestID` from the
   /// database.

--- a/supabase/migrations/20260629142019_add_save_gem_function.sql
+++ b/supabase/migrations/20260629142019_add_save_gem_function.sql
@@ -1,0 +1,46 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.save_gem(gem_id_param uuid, occurred_at_param date, chest_id_param uuid, deleted_line_ids_param bigint[], lines_param jsonb)
+ RETURNS uuid
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  result_id_var uuid;
+  line_var jsonb;
+BEGIN
+  -- Upsert gem
+  INSERT INTO public.gems (id, occurred_at, chest_id)
+  VALUES (COALESCE(gem_id_param, gen_random_uuid()), occurred_at_param, chest_id_param)
+  ON CONFLICT (id) DO UPDATE SET occurred_at = EXCLUDED.occurred_at
+  RETURNING id INTO result_id_var;
+
+  -- Delete removed lines
+  IF array_length(deleted_line_ids_param, 1) > 0 THEN
+    DELETE FROM public.lines WHERE id = ANY(deleted_line_ids_param);
+  END IF;
+
+  -- Upsert all lines
+  FOR line_var IN SELECT * FROM jsonb_array_elements(lines_param)
+  LOOP
+    IF line_var ->> 'id' IS NOT NULL THEN
+      UPDATE public.lines
+      SET text = line_var ->> 'text',
+          person_id = (line_var ->> 'person_id')::bigint
+      WHERE id = (line_var ->> 'id')::bigint;
+    ELSE
+      INSERT INTO public.lines (text, person_id, gem_id, chest_id)
+      VALUES (
+        line_var ->> 'text',
+        (line_var ->> 'person_id')::bigint,
+        result_id_var,
+        chest_id_param
+      );
+    END IF;
+  END LOOP;
+
+  RETURN result_id_var;
+END;
+$function$
+;
+
+

--- a/supabase/schemas/public/functions/save_gem.sql
+++ b/supabase/schemas/public/functions/save_gem.sql
@@ -1,0 +1,47 @@
+CREATE OR REPLACE FUNCTION public.save_gem(
+  gem_id_param uuid,
+  occurred_at_param date,
+  chest_id_param uuid,
+  deleted_line_ids_param bigint[],
+  lines_param jsonb
+)
+  RETURNS uuid
+  LANGUAGE plpgsql
+  AS $function$
+DECLARE
+  result_id_var uuid;
+  line_var jsonb;
+BEGIN
+  -- Upsert gem
+  INSERT INTO public.gems (id, occurred_at, chest_id)
+  VALUES (COALESCE(gem_id_param, gen_random_uuid()), occurred_at_param, chest_id_param)
+  ON CONFLICT (id) DO UPDATE SET occurred_at = EXCLUDED.occurred_at
+  RETURNING id INTO result_id_var;
+
+  -- Delete removed lines
+  IF array_length(deleted_line_ids_param, 1) > 0 THEN
+    DELETE FROM public.lines WHERE id = ANY(deleted_line_ids_param);
+  END IF;
+
+  -- Upsert all lines
+  FOR line_var IN SELECT * FROM jsonb_array_elements(lines_param)
+  LOOP
+    IF line_var ->> 'id' IS NOT NULL THEN
+      UPDATE public.lines
+      SET text = line_var ->> 'text',
+          person_id = (line_var ->> 'person_id')::bigint
+      WHERE id = (line_var ->> 'id')::bigint;
+    ELSE
+      INSERT INTO public.lines (text, person_id, gem_id, chest_id)
+      VALUES (
+        line_var ->> 'text',
+        (line_var ->> 'person_id')::bigint,
+        result_id_var,
+        chest_id_param
+      );
+    END IF;
+  END LOOP;
+
+  RETURN result_id_var;
+END;
+$function$;

--- a/supabase/tests/000_install_basejump.sql
+++ b/supabase/tests/000_install_basejump.sql
@@ -1,0 +1,82 @@
+-- Disable notices (effectively silences RAISE NOTICE)
+SET client_min_messages TO warning;
+
+-- install tests utilities
+-- install pgtap extension for testing
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+
+/*
+---------------------
+---- install dbdev ----
+----------------------
+Requires:
+- pg_tle: https://github.com/aws/pg_tle
+- pgsql-http: https://github.com/pramsey/pgsql-http
+*/
+CREATE EXTENSION IF NOT EXISTS http WITH SCHEMA extensions;
+
+CREATE EXTENSION IF NOT EXISTS pg_tle;
+
+DROP EXTENSION IF EXISTS "supabase-dbdev";
+
+SELECT
+    pgtle.uninstall_extension_if_exists('supabase-dbdev');
+
+SELECT
+    pgtle.install_extension(
+        'supabase-dbdev',
+        resp.contents ->> 'version',
+        'PostgreSQL package manager',
+        resp.contents ->> 'sql'
+    )
+FROM
+    extensions.http(
+        (
+            'GET',
+            'https://api.database.dev/rest/v1/' || 'package_versions?select=sql,version' || '&package_name=eq.supabase-dbdev' || '&order=version.desc' || '&limit=1',
+            ARRAY [('apiKey', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InhtdXB0cHBsZnZpaWZyYndtbXR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE2ODAxMDczNzIsImV4cCI6MTk5NTY4MzM3Mn0.z2CN0mvO2No8wSi46Gw59DFGCTJrzM0AQKsu_5k134s')::extensions.http_header],
+            NULL,
+            NULL
+        )
+    ) x,
+    LATERAL (
+        SELECT
+            (
+                (row_to_json(x) -> 'content') #>> '{}')::json -> 0) resp(contents);
+                CREATE EXTENSION "supabase-dbdev";
+
+SELECT
+    dbdev.install('supabase-dbdev');
+
+DROP EXTENSION IF EXISTS "supabase-dbdev";
+
+CREATE EXTENSION "supabase-dbdev";
+
+-- Install test helpers
+SELECT
+    dbdev.install('basejump-supabase_test_helpers');
+
+CREATE EXTENSION IF NOT EXISTS "basejump-supabase_test_helpers" version '0.0.6';
+
+-- Re-enable notices
+SET client_min_messages TO notice;
+
+
+-- Verify setup with a no-op test
+BEGIN;
+
+SELECT
+    plan(1);
+
+SELECT
+    ok(
+        TRUE,
+        'Pre-test hook completed successfully'
+    );
+
+SELECT
+    *
+FROM
+    finish();
+
+ROLLBACK;

--- a/supabase/tests/001_helpers.sql
+++ b/supabase/tests/001_helpers.sql
@@ -1,0 +1,58 @@
+CREATE OR REPLACE FUNCTION tests.create_chucklechest_user(username_ text)
+RETURNS uuid
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN tests.create_supabase_user(username_, username_ || '@test.com');
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION tests.authenticate_with_claims_as(username_ text)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    _user_id uuid;
+    _claims jsonb;
+    _original_claims text;
+BEGIN
+    PERFORM tests.authenticate_as_service_role();
+
+    _user_id := tests.get_supabase_uid(username_);
+    _claims := (public.custom_access_token_hook(
+        jsonb_build_object('user_id', _user_id, 'claims', '{}'::jsonb)
+    ) -> 'claims');
+
+    PERFORM tests.authenticate_as(username_);
+    _original_claims := current_setting('request.jwt.claims', true);
+
+    PERFORM set_config(
+        'request.jwt.claims',
+        (COALESCE(_original_claims, '{}')::jsonb || _claims)::text,
+        true
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION tests.create_chest(owner_username_ text, chest_name_ text = 'Test Chest')
+RETURNS uuid
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    _chest_id uuid;
+BEGIN
+    PERFORM tests.authenticate_as(owner_username_);
+    INSERT INTO public.chests (name) VALUES (chest_name_)
+    RETURNING id INTO _chest_id;
+    PERFORM tests.authenticate_as_service_role();
+    RETURN _chest_id;
+END;
+$$;
+
+BEGIN;
+SELECT plan(1);
+
+SELECT ok(TRUE, 'helpers completed successfully');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/public/functions/save_gem.test.sql
+++ b/supabase/tests/public/functions/save_gem.test.sql
@@ -1,0 +1,216 @@
+BEGIN;
+SELECT no_plan();
+
+    -- Arrange (shared setup)
+    SELECT tests.create_chucklechest_user('owner');
+    SELECT tests.create_chest('owner') AS chest_id \gset
+
+    SELECT tests.authenticate_as_service_role();
+    INSERT INTO public.people (nickname, date_of_birth, chest_id)
+    VALUES ('Alice', '1990-01-01', :'chest_id')
+    RETURNING id AS person_id \gset
+
+SAVEPOINT arrange_all;
+
+
+    -- Arrange
+    SELECT tests.authenticate_with_claims_as('owner');
+
+    -- Act
+    SELECT public.save_gem(
+        gem_id_param => NULL,
+        occurred_at_param => '2024-06-15'::date,
+        chest_id_param => :'chest_id',
+        deleted_line_ids_param => '{}'::bigint[],
+        lines_param => jsonb_build_array(
+            jsonb_build_object('id', NULL, 'text', 'Once upon a time...', 'person_id', NULL),
+            jsonb_build_object('id', NULL, 'text', 'Hello!', 'person_id', :person_id),
+            jsonb_build_object('id', NULL, 'text', 'The end.', 'person_id', NULL)
+        )
+    ) AS gem_id \gset
+
+    -- Assert
+    SELECT is(
+        (SELECT count(*)::int FROM public.gems WHERE id = :'gem_id'),
+        1,
+        'Given: no existing gem. When: save_gem called with null id. Then: gem created.'
+    );
+
+    SELECT is(
+        (SELECT occurred_at FROM public.gems WHERE id = :'gem_id'),
+        '2024-06-15'::date,
+        'Given: no existing gem. When: save_gem called. Then: occurred_at matches input.'
+    );
+
+    SELECT is(
+        (SELECT count(*)::int FROM public.lines WHERE gem_id = :'gem_id'),
+        3,
+        'Given: no existing gem. When: save_gem called with 3 lines. Then: 3 lines created.'
+    );
+
+    SELECT is(
+        (SELECT person_id FROM public.lines WHERE gem_id = :'gem_id' AND text = 'Hello!'),
+        :person_id::bigint,
+        'Given: line with person_id. When: save_gem called. Then: person_id stored correctly.'
+    );
+
+
+ROLLBACK TO arrange_all;
+
+
+    -- Arrange
+    SELECT tests.authenticate_with_claims_as('owner');
+
+    SELECT public.save_gem(
+        gem_id_param => NULL,
+        occurred_at_param => '2024-06-15'::date,
+        chest_id_param => :'chest_id',
+        deleted_line_ids_param => '{}'::bigint[],
+        lines_param => jsonb_build_array(
+            jsonb_build_object('id', NULL, 'text', 'Line A', 'person_id', NULL),
+            jsonb_build_object('id', NULL, 'text', 'Line B', 'person_id', :person_id),
+            jsonb_build_object('id', NULL, 'text', 'Line C', 'person_id', NULL)
+        )
+    ) AS gem_id \gset
+
+    SELECT
+        ids[1] AS line_a_id,
+        ids[2] AS line_b_id,
+        ids[3] AS line_c_id
+    FROM (
+        SELECT array_agg(id ORDER BY id) AS ids
+        FROM public.lines WHERE gem_id = :'gem_id'
+    ) sub \gset
+
+    -- Act
+    SELECT public.save_gem(
+        gem_id_param => :'gem_id',
+        occurred_at_param => '2024-07-20'::date,
+        chest_id_param => :'chest_id',
+        deleted_line_ids_param => '{}'::bigint[],
+        lines_param => jsonb_build_array(
+            jsonb_build_object('id', :line_a_id, 'text', 'Line A', 'person_id', NULL),
+            jsonb_build_object('id', :line_b_id, 'text', 'Line B updated', 'person_id', :person_id),
+            jsonb_build_object('id', :line_c_id, 'text', 'Line C', 'person_id', NULL)
+        )
+    );
+
+    -- Assert
+    SELECT is(
+        (SELECT occurred_at FROM public.gems WHERE id = :'gem_id'),
+        '2024-07-20'::date,
+        'Given: existing gem. When: save_gem called with new date. Then: date updated.'
+    );
+
+    SELECT is(
+        (SELECT text FROM public.lines WHERE id = :line_b_id),
+        'Line B updated',
+        'Given: existing line. When: save_gem called with new text. Then: text updated.'
+    );
+
+
+ROLLBACK TO arrange_all;
+
+
+    -- Arrange
+    SELECT tests.authenticate_with_claims_as('owner');
+
+    SELECT public.save_gem(
+        gem_id_param => NULL,
+        occurred_at_param => '2024-06-15'::date,
+        chest_id_param => :'chest_id',
+        deleted_line_ids_param => '{}'::bigint[],
+        lines_param => jsonb_build_array(
+            jsonb_build_object('id', NULL, 'text', 'Line A', 'person_id', NULL),
+            jsonb_build_object('id', NULL, 'text', 'Line B', 'person_id', :person_id),
+            jsonb_build_object('id', NULL, 'text', 'Line C', 'person_id', NULL)
+        )
+    ) AS gem_id \gset
+
+    SELECT
+        ids[1] AS line_a_id,
+        ids[2] AS line_b_id,
+        ids[3] AS line_c_id
+    FROM (
+        SELECT array_agg(id ORDER BY id) AS ids
+        FROM public.lines WHERE gem_id = :'gem_id'
+    ) sub \gset
+
+    -- Act
+    SELECT public.save_gem(
+        gem_id_param => :'gem_id',
+        occurred_at_param => '2024-06-15'::date,
+        chest_id_param => :'chest_id',
+        deleted_line_ids_param => ARRAY[:line_b_id]::bigint[],
+        lines_param => jsonb_build_array(
+            jsonb_build_object('id', :line_a_id, 'text', 'Line A', 'person_id', NULL),
+            jsonb_build_object('id', :line_c_id, 'text', 'Line C', 'person_id', NULL)
+        )
+    );
+
+    -- Assert
+    SELECT is(
+        (SELECT count(*)::int FROM public.lines WHERE gem_id = :'gem_id'),
+        2,
+        'Given: gem with 3 lines. When: middle line deleted. Then: 2 lines remain.'
+    );
+
+    SELECT is(
+        (SELECT count(*)::int FROM public.lines WHERE id = :line_b_id),
+        0,
+        'Given: gem with 3 lines. When: middle line deleted. Then: deleted line gone from DB.'
+    );
+
+
+ROLLBACK TO arrange_all;
+
+
+    -- Arrange
+    SELECT tests.authenticate_with_claims_as('owner');
+
+    SELECT public.save_gem(
+        gem_id_param => NULL,
+        occurred_at_param => '2024-06-15'::date,
+        chest_id_param => :'chest_id',
+        deleted_line_ids_param => '{}'::bigint[],
+        lines_param => jsonb_build_array(
+            jsonb_build_object('id', NULL, 'text', 'Line A', 'person_id', NULL),
+            jsonb_build_object('id', NULL, 'text', 'Line B', 'person_id', NULL)
+        )
+    ) AS gem_id \gset
+
+    SELECT
+        ids[1] AS line_a_id,
+        ids[2] AS line_b_id
+    FROM (
+        SELECT array_agg(id ORDER BY id) AS ids
+        FROM public.lines WHERE gem_id = :'gem_id'
+    ) sub \gset
+
+    -- Act
+    SELECT public.save_gem(
+        gem_id_param => :'gem_id',
+        occurred_at_param => '2024-06-15'::date,
+        chest_id_param => :'chest_id',
+        deleted_line_ids_param => ARRAY[:line_b_id]::bigint[],
+        lines_param => jsonb_build_array(
+            jsonb_build_object('id', :line_a_id, 'text', 'Line A', 'person_id', NULL),
+            jsonb_build_object('id', NULL, 'text', 'New line', 'person_id', :person_id)
+        )
+    );
+
+    -- Assert
+    SELECT is(
+        (SELECT count(*)::int FROM public.lines WHERE gem_id = :'gem_id'),
+        2,
+        'Given: gem with deleted line. When: new line added in same save. Then: count stays 2.'
+    );
+
+    SELECT ok(
+        (SELECT EXISTS(SELECT 1 FROM public.lines WHERE gem_id = :'gem_id' AND text = 'New line')),
+        'Given: gem with deleted line. When: new line added in same save. Then: new line exists.'
+    );
+
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/wiki/Testing.md
+++ b/wiki/Testing.md
@@ -4,10 +4,70 @@
 
 ChuckleChest uses a layered testing approach:
 
-| Layer      | Location              | What's Tested                      |
-| ---------- | --------------------- | ---------------------------------- |
-| Unit tests | `packages/*/test/`    | Repositories, clients in isolation |
-| E2E tests  | `app/test/pages/*/`   | Full app flows with mocked clients |
+| Layer          | Location              | What's Tested                        |
+| -------------- | --------------------- | ------------------------------------ |
+| Supabase tests | `supabase/tests/`     | DB functions, triggers, RLS policies |
+| Unit tests     | `packages/*/test/`    | Repositories, clients in isolation   |
+| E2E tests      | `app/test/pages/*/`   | Full app flows with mocked clients   |
+
+### Supabase Tests
+
+pgTAP tests for every DB function, trigger, and RLS policy change. More
+important than Dart tests — if the DB is wrong, the app is wrong.
+
+Run: `hobnob db:test`
+
+Before writing tests, read `supabase/tests/001_helpers.sql` — helpers change
+frequently, new ones can be added there (add shared helpers there, not inline).
+
+#### Structure
+
+```sql
+BEGIN;
+SELECT no_plan();  -- Always no_plan(), never plan(N)
+
+    -- Arrange (one-time setup shared across all scenarios)
+    SELECT tests.create_chucklechest_user('owner');
+    SELECT tests.create_chest('owner') AS chest_id \gset
+
+SAVEPOINT arrange_all;
+
+
+    -- Arrange
+    SELECT tests.authenticate_with_claims_as('owner');
+
+    -- Act
+    SELECT public.some_function(:'chest_id') AS result \gset
+
+    -- Assert (one is() / ok() / throws_ok() per requirement)
+    SELECT is(
+        (SELECT count(*)::int FROM public.some_table WHERE chest_id = :'chest_id'),
+        1,
+        'Given: owner authenticated. When: some_function called. Then: record created.'
+    );
+
+
+ROLLBACK TO arrange_all;
+
+
+    -- (next scenario from same base state)
+
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+#### Rules
+
+- `no_plan()` always — never `plan(N)`
+- `SAVEPOINT arrange_all` + `ROLLBACK TO arrange_all` between scenarios — resets
+  to shared base state
+- One `is()` / `ok()` / `throws_ok()` per test — one requirement per assertion
+- Test descriptions: `'Given: ... When: ... Then: ...'`
+- AAA comments on every scenario: `-- Arrange`, `-- Act`, `-- Assert`
+- Use `\gset` to capture return values: `SELECT fn() AS var \gset` → `:var`
+- Authenticate before every Act: `tests.authenticate_with_claims_as('user')` or
+  `tests.authenticate_as_service_role()`
 
 ### E2E Tests
 


### PR DESCRIPTION
- Move gem save logic into a single `save_gem` Postgres function that upserts gem+lines and deletes arbitrary line IDs atomically
- Add pgTAP test infra (`db:test` in hobnob.yml) covering `save_gem`
- Update wiki/Testing.md docs