### PR TITLE
fix: only start db service in CI pipeline

### DIFF
--- a/hobnobs/database.yml
+++ b/hobnobs/database.yml
@@ -12,7 +12,7 @@ tasks:
   test:
     info: Run tests against the local Supabase database.
     steps:
-      - call: start
+      - run: supabase start db # Only start db in CI pipeline.
       - run: supabase db test
 
   reset:


### PR DESCRIPTION
Only start the `db` service instead of the full Supabase stack during CI tests. Avoids pulling auth, realtime, storage, and other unused Docker images — `supabase db test` only needs Postgres.