### PR TITLE
Add like gems feature with favourites collection

### DIFF
--- a/app/lib/app/bootstrap/dependencies_provider.dart
+++ b/app/lib/app/bootstrap/dependencies_provider.dart
@@ -92,6 +92,7 @@ class _CAppDependenciesProviderState extends State<CAppDependenciesProvider> {
       final invitationsTable = CInvitationsTable(supabaseClient);
       final userRolesTable = CUserRolesTable(supabaseClient);
       final gemShareTokensTable = CGemShareTokensTable(supabaseClient);
+      final gemLikesTable = CGemLikesTable(supabaseClient);
 
       platformClient = CPlatformClient();
       authClient = CAuthClient(authClient: supabaseClient.auth);
@@ -105,6 +106,7 @@ class _CAppDependenciesProviderState extends State<CAppDependenciesProvider> {
         gemsTable: gemsTable,
         linesTable: linesTable,
         gemShareTokensTable: gemShareTokensTable,
+        gemLikesTable: gemLikesTable,
         supabaseClient: supabaseClient,
       );
       personClient = CPersonClient(

--- a/app/lib/app/routes.dart
+++ b/app/lib/app/routes.dart
@@ -135,6 +135,10 @@ class CAppRouter extends RootStackRouter implements AutoRouteGuard {
               page: CRandomCollectionRoute.page,
             ),
             AutoRoute(
+              path: 'collections/favourites',
+              page: CFavouritesCollectionRoute.page,
+            ),
+            AutoRoute(
               path: 'people/edit-person',
               page: CEditPersonRoute.page,
               guards: [CCollaboratorGuard()],

--- a/app/lib/app/routes.gr.dart
+++ b/app/lib/app/routes.gr.dart
@@ -348,6 +348,22 @@ class CEditPersonRouteArgs {
 }
 
 /// generated route for
+/// [CFavouritesCollectionPage]
+class CFavouritesCollectionRoute extends PageRouteInfo<void> {
+  const CFavouritesCollectionRoute({List<PageRouteInfo>? children})
+    : super(CFavouritesCollectionRoute.name, initialChildren: children);
+
+  static const String name = 'CFavouritesCollectionRoute';
+
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      return WrappedRoute(child: const CFavouritesCollectionPage());
+    },
+  );
+}
+
+/// generated route for
 /// [CGemPage]
 class CGemRoute extends PageRouteInfo<CGemRouteArgs> {
   CGemRoute({required String gemID, Key? key, List<PageRouteInfo>? children})

--- a/app/lib/localization/arb/intl_de.arb
+++ b/app/lib/localization/arb/intl_de.arb
@@ -22,6 +22,7 @@
   "collectionView_shareSheet_createLinkButton": "Link erstellen",
   "collectionView_shareSheet_deleteLinkButton": "Link löschen",
   "collectionView_shareSheet_shareLinkButton": "Link teilen",
+  "collectionsPage_collection_favourites": "Deine Favoriten",
   "collectionsPage_collection_random": "Zufällig ausgewählt",
   "collectionsPage_collection_recents": "Zuletzt hinzugefügt",
   "collectionsPage_noGemsMessage": "Erstelle eine neue Gemme, um loszulegen.",

--- a/app/lib/localization/arb/intl_en.arb
+++ b/app/lib/localization/arb/intl_en.arb
@@ -22,6 +22,7 @@
   "collectionView_shareSheet_createLinkButton": "Create a share link",
   "collectionView_shareSheet_deleteLinkButton": "Delete the link",
   "collectionView_shareSheet_shareLinkButton": "Share the link",
+  "collectionsPage_collection_favourites": "Your favourites",
   "collectionsPage_collection_random": "Randomly selected",
   "collectionsPage_collection_recents": "Recently added",
   "collectionsPage_noGemsMessage": "Create a new gem to get started.",

--- a/app/lib/localization/generated/localizations.g.dart
+++ b/app/lib/localization/generated/localizations.g.dart
@@ -187,6 +187,12 @@ abstract class CAppL10n {
   /// **'Share the link'**
   String get collectionView_shareSheet_shareLinkButton;
 
+  /// No description provided for @collectionsPage_collection_favourites.
+  ///
+  /// In en, this message translates to:
+  /// **'Your favourites'**
+  String get collectionsPage_collection_favourites;
+
   /// No description provided for @collectionsPage_collection_random.
   ///
   /// In en, this message translates to:

--- a/app/lib/localization/generated/localizations_de.g.dart
+++ b/app/lib/localization/generated/localizations_de.g.dart
@@ -59,6 +59,9 @@ class CAppL10nDe extends CAppL10n {
   String get collectionView_shareSheet_shareLinkButton => 'Link teilen';
 
   @override
+  String get collectionsPage_collection_favourites => 'Deine Favoriten';
+
+  @override
   String get collectionsPage_collection_random => 'Zufällig ausgewählt';
 
   @override

--- a/app/lib/localization/generated/localizations_en.g.dart
+++ b/app/lib/localization/generated/localizations_en.g.dart
@@ -60,6 +60,9 @@ class CAppL10nEn extends CAppL10n {
   String get collectionView_shareSheet_shareLinkButton => 'Share the link';
 
   @override
+  String get collectionsPage_collection_favourites => 'Your favourites';
+
+  @override
   String get collectionsPage_collection_random => 'Randomly selected';
 
   @override

--- a/app/lib/pages/_pages.dart
+++ b/app/lib/pages/_pages.dart
@@ -7,6 +7,7 @@ export 'create_gem/page.dart';
 export 'demo/page.dart';
 export 'edit_gem/page.dart';
 export 'edit_person/page.dart';
+export 'favourites_collection/page.dart';
 export 'gem/page.dart';
 export 'get_started/page.dart';
 export 'home/page.dart';

--- a/app/lib/pages/chest/page.dart
+++ b/app/lib/pages/chest/page.dart
@@ -38,18 +38,24 @@ class CChestPage extends StatelessWidget implements AutoRouteWrapper {
         authRepository: context.read(),
       ),
       child: BlocProvider(
-        create: (context) =>
-            CChestPeopleFetchCubit(personRepository: context.read())
-              ..fetchChestPeople(
-                chestID: context.read<CCurrentChestCubit>().state.id,
-              ),
-        child: BlocListener<CChestPeopleFetchCubit, CChestPeopleFetchState>(
-          listener: (context, _) =>
-              context.read<CAppSettingsCubit>().updateLastViewedChest(
-                context.read<CCurrentChestCubit>().state.id,
-              ),
-          listenWhen: (_, state) => state.succeeded,
-          child: this,
+        create: (context) => CGemLikesCubit(
+          gemRepository: context.read(),
+          chestID: context.read<CCurrentChestCubit>().state.id,
+        )..fetchLikedGemIDs(),
+        child: BlocProvider(
+          create: (context) =>
+              CChestPeopleFetchCubit(personRepository: context.read())
+                ..fetchChestPeople(
+                  chestID: context.read<CCurrentChestCubit>().state.id,
+                ),
+          child: BlocListener<CChestPeopleFetchCubit, CChestPeopleFetchState>(
+            listener: (context, _) =>
+                context.read<CAppSettingsCubit>().updateLastViewedChest(
+                  context.read<CCurrentChestCubit>().state.id,
+                ),
+            listenWhen: (_, state) => state.succeeded,
+            child: this,
+          ),
         ),
       ),
     );

--- a/app/lib/pages/collections/page.dart
+++ b/app/lib/pages/collections/page.dart
@@ -57,6 +57,7 @@ class CCollectionsPage extends StatelessWidget implements AutoRouteWrapper {
             const SizedBox(height: 8),
             const CRecentsCollectionTile(),
             const CRandomCollectionTile(),
+            const CFavouritesCollectionTile(),
           ],
         ),
       ),

--- a/app/lib/pages/collections/widgets/_widgets.dart
+++ b/app/lib/pages/collections/widgets/_widgets.dart
@@ -1,3 +1,4 @@
+export 'favourites_collection_tile.dart';
 export 'random_collection_tile.dart';
 export 'recents_collection_tile.dart';
 export 'year_collections_section.dart';

--- a/app/lib/pages/collections/widgets/favourites_collection_tile.dart
+++ b/app/lib/pages/collections/widgets/favourites_collection_tile.dart
@@ -1,0 +1,24 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:chuckle_chest/app/routes.dart';
+import 'package:chuckle_chest/localization/l10n.dart';
+import 'package:flutter/material.dart';
+
+/// {@template CFavouritesCollectionTile}
+///
+/// The tile for the favourites collection on the collections page.
+///
+/// {@endtemplate}
+class CFavouritesCollectionTile extends StatelessWidget {
+  /// {@macro CFavouritesCollectionTile}
+  const CFavouritesCollectionTile({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      minVerticalPadding: 16,
+      leading: const Icon(Icons.favorite_rounded),
+      title: Text(context.cAppL10n.collectionsPage_collection_favourites),
+      onTap: () => context.router.push(const CFavouritesCollectionRoute()),
+    );
+  }
+}

--- a/app/lib/pages/demo/page.dart
+++ b/app/lib/pages/demo/page.dart
@@ -30,6 +30,7 @@ class CDemoPage extends StatelessWidget implements AutoRouteWrapper {
       body: CCollectionView<CDemoCubit, CDemoState, BobsNothing, CSharedGem>(
         gemTokens: cubit.gemTokens,
         userRole: CUserRole.viewer,
+        isShared: true,
         gemFromState: (state) => state.gem,
         gemTokenFromState: (state) => state.gemID,
         triggerFetchGem: (context, token) => cubit.emitGemWithToken(token),

--- a/app/lib/pages/favourites_collection/logic/_logic.dart
+++ b/app/lib/pages/favourites_collection/logic/_logic.dart
@@ -1,0 +1,1 @@
+export 'favourite_gem_ids_fetch_cubit.dart';

--- a/app/lib/pages/favourites_collection/logic/favourite_gem_ids_fetch_cubit.dart
+++ b/app/lib/pages/favourites_collection/logic/favourite_gem_ids_fetch_cubit.dart
@@ -1,0 +1,31 @@
+import 'package:bloc/bloc.dart';
+import 'package:cgem_repository/cgem_repository.dart';
+import 'package:mallard_bloc/mallard_bloc.dart';
+
+/// The state for the [CFavouriteGemIDsFetchCubit].
+typedef CFavouriteGemIDsFetchState =
+    TaskBlocState<List<String>, CGemIDsFetchException>;
+
+/// {@template CFavouriteGemIDsFetchCubit}
+///
+/// The cubit for handling fetching the IDs of the liked gems.
+///
+/// {@endtemplate}
+class CFavouriteGemIDsFetchCubit extends Cubit<CFavouriteGemIDsFetchState>
+    with TaskCubitMixin {
+  /// {@macro CFavouriteGemIDsFetchCubit}
+  CFavouriteGemIDsFetchCubit({
+    required this.gemRepository,
+    required this.chestID,
+  }) : super(TaskBlocState.initial());
+
+  /// The repository this cubit uses to fetch the gem IDs.
+  final CGemRepository gemRepository;
+
+  /// The ID of the chest to fetch the liked gems from.
+  final String chestID;
+
+  /// Fetches the IDs of the liked gems.
+  Future<void> fetchLikedGemIDs() =>
+      request(gemRepository.fetchLikedGemIDs(chestID: chestID));
+}

--- a/app/lib/pages/favourites_collection/page.dart
+++ b/app/lib/pages/favourites_collection/page.dart
@@ -1,0 +1,81 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:cgem_repository/cgem_repository.dart';
+import 'package:chuckle_chest/pages/favourites_collection/logic/_logic.dart';
+import 'package:chuckle_chest/shared/_shared.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mallard_bloc/mallard_bloc.dart';
+
+/// {@template CFavouritesCollectionPage}
+///
+/// The page for displaying a collection of the gems the user has liked.
+///
+/// It fetches the IDs of the liked gems and then displays them in a
+/// [CCollectionView] which allow the user to view the gems one by one.
+///
+/// {@endtemplate}
+@RoutePage()
+class CFavouritesCollectionPage extends StatelessWidget
+    implements AutoRouteWrapper {
+  /// {@macro CFavouritesCollectionPage}
+  const CFavouritesCollectionPage({super.key});
+
+  @override
+  Widget wrappedRoute(BuildContext context) {
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider(
+          create: (context) => CFavouriteGemIDsFetchCubit(
+            gemRepository: context.read(),
+            chestID: context.read<CCurrentChestCubit>().state.id,
+          )..fetchLikedGemIDs(),
+        ),
+        BlocProvider(
+          create: (context) => CGemFetchCubit(gemRepository: context.read()),
+        ),
+      ],
+      child: this,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<CFavouriteGemIDsFetchCubit, CFavouriteGemIDsFetchState>(
+      builder: (context, state) => Scaffold(
+        body: switch (state.status) {
+          TaskBlocStatus.initial => const Center(
+            child: CCradleLoadingIndicator(),
+          ),
+          TaskBlocStatus.inProgress => const Center(
+            child: CCradleLoadingIndicator(),
+          ),
+          TaskBlocStatus.failed => const Center(
+            child: Icon(Icons.error_rounded),
+          ),
+          TaskBlocStatus.succeeded =>
+            CCollectionView<
+              CGemFetchCubit,
+              CGemFetchState,
+              CGemFetchException,
+              CGem
+            >(
+              gemTokens: state.success!,
+              userRole: context.read<CCurrentChestCubit>().state.userRole,
+              gemFromState: (state) => state.gem,
+              gemTokenFromState: (state) => state.gemID,
+              triggerFetchGem: (context, token) =>
+                  context.read<CGemFetchCubit>().fetchGem(gemID: token),
+              onFetchFailed: (failure) => switch (failure) {
+                CGemFetchException.notFound => const CErrorSnackBar(
+                  message: "We couldn't find that gem.",
+                ).show(context),
+                CGemFetchException.unknown => const CErrorSnackBar().show(
+                  context,
+                ),
+              },
+            ),
+        },
+      ),
+    );
+  }
+}

--- a/app/lib/pages/shared_gem/page.dart
+++ b/app/lib/pages/shared_gem/page.dart
@@ -42,6 +42,7 @@ class CSharedGemPage extends StatelessWidget implements AutoRouteWrapper {
           >(
             gemTokens: [shareToken ?? ''],
             userRole: CUserRole.viewer,
+            isShared: true,
             gemFromState: (state) => state.gem,
             gemTokenFromState: (state) => shareToken ?? '',
             triggerFetchGem: (context, token) => context

--- a/app/lib/shared/logic/_logic.dart
+++ b/app/lib/shared/logic/_logic.dart
@@ -4,6 +4,7 @@ export 'current_chest_cubit.dart';
 export 'current_user_cubit.dart';
 export 'gem_fetch_cubit.dart';
 export 'gem_fetch_from_share_token.dart';
+export 'gem_likes_cubit.dart';
 export 'invitation_accept_cubit.dart';
 export 'request_cubit.dart';
 export 'signout_cubit.dart';

--- a/app/lib/shared/logic/gem_likes_cubit.dart
+++ b/app/lib/shared/logic/gem_likes_cubit.dart
@@ -1,0 +1,136 @@
+import 'package:bloc/bloc.dart';
+import 'package:cgem_repository/cgem_repository.dart';
+import 'package:equatable/equatable.dart';
+
+/// The status of the [CGemLikesState].
+enum CGemLikesStatus {
+  /// The liked gem IDs have not been fetched yet.
+  initial,
+
+  /// The liked gem IDs are being fetched.
+  inProgress,
+
+  /// The liked gem IDs failed to be fetched.
+  failed,
+
+  /// The liked gem IDs have been fetched.
+  succeeded,
+}
+
+/// {@template CGemLikesState}
+///
+/// The state for the [CGemLikesCubit].
+///
+/// {@endtemplate}
+class CGemLikesState extends Equatable {
+  /// {@macro CGemLikesState}
+  const CGemLikesState({
+    required this.status,
+    required this.likedGemIDs,
+    required this.pendingGemIDs,
+  });
+
+  /// {@macro CGemLikesState}
+  ///
+  /// The initial state.
+  const CGemLikesState.initial()
+    : this(
+        status: CGemLikesStatus.initial,
+        likedGemIDs: const {},
+        pendingGemIDs: const {},
+      );
+
+  /// The status of the liked gem IDs fetch.
+  final CGemLikesStatus status;
+
+  /// The IDs of the gems the user has liked.
+  final Set<String> likedGemIDs;
+
+  /// The IDs of the gems that have an in-flight like/unlike toggle.
+  final Set<String> pendingGemIDs;
+
+  /// Returns a copy of this state with the given fields replaced.
+  CGemLikesState copyWith({
+    CGemLikesStatus? status,
+    Set<String>? likedGemIDs,
+    Set<String>? pendingGemIDs,
+  }) => CGemLikesState(
+    status: status ?? this.status,
+    likedGemIDs: likedGemIDs ?? this.likedGemIDs,
+    pendingGemIDs: pendingGemIDs ?? this.pendingGemIDs,
+  );
+
+  @override
+  List<Object?> get props => [status, likedGemIDs, pendingGemIDs];
+}
+
+/// {@template CGemLikesCubit}
+///
+/// The cubit that caches which gems in a chest the user has liked and lets
+/// the user toggle a gem's liked status.
+///
+/// {@endtemplate}
+class CGemLikesCubit extends Cubit<CGemLikesState> {
+  /// {@macro CGemLikesCubit}
+  CGemLikesCubit({required this.gemRepository, required this.chestID})
+    : super(const CGemLikesState.initial());
+
+  /// The repository this cubit uses to like/unlike gems.
+  final CGemRepository gemRepository;
+
+  /// The ID of the chest the liked gems belong to.
+  final String chestID;
+
+  /// Fetches the IDs of the gems the user has liked in this chest.
+  Future<void> fetchLikedGemIDs() async {
+    emit(state.copyWith(status: CGemLikesStatus.inProgress));
+
+    final result = await gemRepository.fetchLikedGemIDs(chestID: chestID).run();
+
+    result.resolve(
+      onSuccess: (ids) => emit(
+        state.copyWith(
+          status: CGemLikesStatus.succeeded,
+          likedGemIDs: ids.toSet(),
+        ),
+      ),
+      onFailure: (_) => emit(state.copyWith(status: CGemLikesStatus.failed)),
+    );
+  }
+
+  /// Toggles the liked status of the gem with the given [gemID].
+  Future<void> toggle(String gemID) async {
+    final wasLiked = state.likedGemIDs.contains(gemID);
+
+    emit(
+      state.copyWith(
+        likedGemIDs: wasLiked
+            ? (Set.of(state.likedGemIDs)..remove(gemID))
+            : (Set.of(state.likedGemIDs)..add(gemID)),
+        pendingGemIDs: Set.of(state.pendingGemIDs)..add(gemID),
+      ),
+    );
+
+    final task = wasLiked
+        ? gemRepository.unlikeGem(gemID: gemID)
+        : gemRepository.likeGem(chestID: chestID, gemID: gemID);
+
+    final result = await task.run();
+
+    result.resolve(
+      onSuccess: (_) => emit(
+        state.copyWith(
+          pendingGemIDs: Set.of(state.pendingGemIDs)..remove(gemID),
+        ),
+      ),
+      onFailure: (_) => emit(
+        state.copyWith(
+          likedGemIDs: wasLiked
+              ? (Set.of(state.likedGemIDs)..add(gemID))
+              : (Set.of(state.likedGemIDs)..remove(gemID)),
+          pendingGemIDs: Set.of(state.pendingGemIDs)..remove(gemID),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/shared/views/collection/view.dart
+++ b/app/lib/shared/views/collection/view.dart
@@ -32,6 +32,7 @@ class CCollectionView<
     required this.gemTokenFromState,
     required this.onFetchFailed,
     required this.triggerFetchGem,
+    this.isShared = false,
     super.key,
   });
 
@@ -44,6 +45,12 @@ class CCollectionView<
   ///
   /// If the user is not authenticated, this should be [CUserRole.viewer].
   final CUserRole userRole;
+
+  /// Whether this view is being shown on the public shared-gem page.
+  ///
+  /// When `true`, no bottom app bar is displayed, since sharing and liking
+  /// gems both require the user to be viewing gems within a chest.
+  final bool isShared;
 
   /// The function to extract the gem from the state.
   final CGem Function(S state) gemFromState;
@@ -165,11 +172,12 @@ class _CCollectionViewState<
           ),
         ),
       ),
-      bottomNavigationBar: widget.userRole != CUserRole.viewer
-          ? CCollectionViewBottomAppBar(
+      bottomNavigationBar: widget.isShared
+          ? null
+          : CCollectionViewBottomAppBar(
+              showShareButton: widget.userRole != CUserRole.viewer,
               onShared: (token) => _shareGem(context, token),
-            )
-          : null,
+            ),
     );
   }
 

--- a/app/lib/shared/views/collection/widgets/_widgets.dart
+++ b/app/lib/shared/views/collection/widgets/_widgets.dart
@@ -1,4 +1,5 @@
 export 'animated_gem.dart';
 export 'app_bar.dart';
 export 'bottom_app_bar.dart';
+export 'like_button.dart';
 export 'share_sheet.dart';

--- a/app/lib/shared/views/collection/widgets/bottom_app_bar.dart
+++ b/app/lib/shared/views/collection/widgets/bottom_app_bar.dart
@@ -15,7 +15,14 @@ import 'package:signed_spacing_flex/signed_spacing_flex.dart';
 /// {@endtemplate}
 class CCollectionViewBottomAppBar extends StatelessWidget {
   /// {@macro CCollectionViewBottomAppBar}
-  const CCollectionViewBottomAppBar({required this.onShared, super.key});
+  const CCollectionViewBottomAppBar({
+    required this.showShareButton,
+    required this.onShared,
+    super.key,
+  });
+
+  /// Whether the share button should be displayed.
+  final bool showShareButton;
 
   /// Called when the share button is pressed.
   final void Function(String token) onShared;
@@ -26,38 +33,40 @@ class CCollectionViewBottomAppBar extends StatelessWidget {
       child: SignedSpacingRow(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          BlocBuilder<CCollectionViewCubit, CCollectionViewState>(
-            builder: (context, viewState) =>
-                BlocBuilder<CGemShareCubit, CGemShareState>(
-                  builder: (context, shareState) =>
-                      BlocBuilder<
-                        CGemShareTokenCreationCubit,
-                        CGemShareTokenCreationState
-                      >(
-                        builder: (context, tokenState) => IconButton(
-                          onPressed:
-                              viewState.currentGem != null &&
-                                  shareState.status !=
-                                      CRequestCubitStatus.inProgress &&
-                                  tokenState.status !=
-                                      CRequestCubitStatus.inProgress
-                              ? () => CShareSheet(
-                                  gem: viewState.currentGem!,
-                                  onShared: onShared,
-                                  shareTokenCreationCubit: context.read(),
-                                ).show(context)
-                              : null,
-                          icon:
-                              shareState.status !=
-                                      CRequestCubitStatus.inProgress &&
-                                  tokenState.status !=
-                                      CRequestCubitStatus.inProgress
-                              ? const Icon(Icons.share_rounded)
-                              : const CBouncyBallLoadingIndicator(),
+          const CGemLikeButton(),
+          if (showShareButton)
+            BlocBuilder<CCollectionViewCubit, CCollectionViewState>(
+              builder: (context, viewState) =>
+                  BlocBuilder<CGemShareCubit, CGemShareState>(
+                    builder: (context, shareState) =>
+                        BlocBuilder<
+                          CGemShareTokenCreationCubit,
+                          CGemShareTokenCreationState
+                        >(
+                          builder: (context, tokenState) => IconButton(
+                            onPressed:
+                                viewState.currentGem != null &&
+                                    shareState.status !=
+                                        CRequestCubitStatus.inProgress &&
+                                    tokenState.status !=
+                                        CRequestCubitStatus.inProgress
+                                ? () => CShareSheet(
+                                    gem: viewState.currentGem!,
+                                    onShared: onShared,
+                                    shareTokenCreationCubit: context.read(),
+                                  ).show(context)
+                                : null,
+                            icon:
+                                shareState.status !=
+                                        CRequestCubitStatus.inProgress &&
+                                    tokenState.status !=
+                                        CRequestCubitStatus.inProgress
+                                ? const Icon(Icons.share_rounded)
+                                : const CBouncyBallLoadingIndicator(),
+                          ),
                         ),
-                      ),
-                ),
-          ),
+                  ),
+            ),
         ],
       ),
     );

--- a/app/lib/shared/views/collection/widgets/like_button.dart
+++ b/app/lib/shared/views/collection/widgets/like_button.dart
@@ -1,0 +1,47 @@
+import 'package:chuckle_chest/shared/_shared.dart';
+import 'package:chuckle_chest/shared/views/collection/logic/_logic.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// {@template CGemLikeButton}
+///
+/// The button that toggles whether the current gem in a [CCollectionView] is
+/// liked.
+///
+/// {@endtemplate}
+class CGemLikeButton extends StatelessWidget {
+  /// {@macro CGemLikeButton}
+  const CGemLikeButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<CCollectionViewCubit, CCollectionViewState>(
+      builder: (context, viewState) {
+        final gemID = viewState.currentGem?.id;
+
+        return BlocBuilder<CGemLikesCubit, CGemLikesState>(
+          builder: (context, likeState) {
+            final isLiked =
+                gemID != null && likeState.likedGemIDs.contains(gemID);
+            final isPending =
+                gemID != null && likeState.pendingGemIDs.contains(gemID);
+
+            return IconButton(
+              key: const Key('collection_view_like_button'),
+              onPressed: gemID == null || isPending
+                  ? null
+                  : () => context.read<CGemLikesCubit>().toggle(gemID),
+              icon: isPending
+                  ? const CBouncyBallLoadingIndicator()
+                  : Icon(
+                      isLiked
+                          ? Icons.favorite_rounded
+                          : Icons.favorite_border_rounded,
+                    ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/app/test/helpers/test_clients.dart
+++ b/app/test/helpers/test_clients.dart
@@ -3,6 +3,7 @@ import 'package:cauth_client/cauth_client.dart';
 import 'package:cdatabase_client/cdatabase_client.dart';
 import 'package:cplatform_client/cplatform_client.dart';
 import 'package:cstorage_client/cstorage_client.dart';
+import 'package:mallard/mallard.dart';
 import 'package:mocktail/mocktail.dart';
 
 class MockCAuthClient extends Mock implements CAuthClient {}
@@ -25,6 +26,9 @@ class CTestClients {
         stream: () => Stream.value(bobsSuccess(bobsAbsent())),
       ),
     );
+    when(
+      () => gemClient.fetchLikedGemIDs(chestID: any(named: 'chestID')),
+    ).thenReturn(Task.succeed(<String>[]));
   }
 
   final authClient = MockCAuthClient();

--- a/app/test/pages/favourites_collection/like_gem_test.dart
+++ b/app/test/pages/favourites_collection/like_gem_test.dart
@@ -1,0 +1,205 @@
+import 'package:bobs_jobs/bobs_jobs.dart';
+import 'package:cauth_client/cauth_client.dart';
+import 'package:ccore/ccore.dart';
+import 'package:cdatabase_client/cdatabase_client.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mallard/mallard.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test_beautifier/test_beautifier.dart';
+
+import '../../helpers/helpers.dart';
+
+const _chestID = 'chest-1';
+const _gemID = 'gem-1';
+
+const Key _likeButtonKey = Key('collection_view_like_button');
+
+const _fakeRawOwnerChest = CRawAuthUserChest(
+  id: _chestID,
+  name: 'Test Chest',
+  userRole: CUserRole.owner,
+);
+
+const _fakeRawViewerChest = CRawAuthUserChest(
+  id: _chestID,
+  name: 'Test Chest',
+  userRole: CUserRole.viewer,
+);
+
+CRawAuthUser _fakeRawUser(CRawAuthUserChest chest) => CRawAuthUser(
+  id: 'user-1',
+  username: 'testuser',
+  email: 'test@example.com',
+  chests: [chest],
+);
+
+CRawGem _makeRawGem(String id) => CRawGem(
+  {
+    'id': id,
+    'chest_id': _chestID,
+    'number': 1,
+    'occurred_at': '2024-01-15T10:00:00.000Z',
+    'lines': <Map<String, dynamic>>[],
+    'gem_share_tokens': null,
+  },
+  null,
+);
+
+void _setupSignedInUser(CTestClients clients, CRawAuthUserChest chest) {
+  final user = _fakeRawUser(chest);
+  when(clients.authClient.currentUserStream).thenAnswer(
+    (_) => BobsStream(
+      stream: () => Stream.value(bobsSuccess(bobsPresent(user))),
+    ),
+  );
+  when(() => clients.authClient.currentUser).thenReturn(user);
+  when(
+    clients.authClient.refreshSession,
+  ).thenReturn(bobsFakeSuccessJob(bobsNothing));
+}
+
+void _setupChest(
+  CTestClients clients, {
+  required List<String> gemIDs,
+  List<String> likedGemIDs = const [],
+}) {
+  when(
+    () => clients.personClient.fetchChestPeople(
+      chestID: any(named: 'chestID'),
+    ),
+  ).thenReturn(bobsFakeSuccessJob(<CRawPerson>[]));
+
+  when(
+    () => clients.gemClient.fetchGemYears(chestID: any(named: 'chestID')),
+  ).thenReturn(bobsFakeSuccessJob(<int>[]));
+
+  when(
+    () => clients.gemClient.fetchRecentGemIDs(
+      chestID: any(named: 'chestID'),
+      limit: any(named: 'limit'),
+    ),
+  ).thenReturn(bobsFakeSuccessJob(gemIDs));
+
+  for (final id in gemIDs) {
+    when(
+      () => clients.gemClient.fetchGem(gemID: id),
+    ).thenReturn(bobsFakeSuccessJob(_makeRawGem(id)));
+  }
+
+  when(
+    () => clients.gemClient.fetchLikedGemIDs(chestID: any(named: 'chestID')),
+  ).thenReturn(Task.succeed(likedGemIDs));
+
+  when(
+    () => clients.gemClient.likeGem(
+      chestID: any(named: 'chestID'),
+      gemID: any(named: 'gemID'),
+    ),
+  ).thenReturn(Task.succeed(_gemID));
+
+  when(
+    () => clients.gemClient.unlikeGem(gemID: any(named: 'gemID')),
+  ).thenReturn(Task.succeed(_gemID));
+}
+
+void main() {
+  group('Like Gem Tests', () {
+    late CTestClients clients;
+
+    setUp(() {
+      clients = CTestClients();
+    });
+
+    testWidgets(
+      requirement(
+        given: 'owner viewing an unliked gem',
+        whenever: 'the like button is tapped',
+        then: 'calls likeGem with the chest and gem ID',
+        why: 'liking a gem must persist the like exactly once',
+      ),
+      (tester) async {
+        _setupSignedInUser(clients, _fakeRawOwnerChest);
+        _setupChest(clients, gemIDs: [_gemID]);
+
+        await tester.pumpChuckleChestApp(
+          clients: clients,
+          startAt: '/chest/collections/recently-added',
+        );
+
+        await tester.tap(find.byKey(_likeButtonKey));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => clients.gemClient.likeGem(chestID: _chestID, gemID: _gemID),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      requirement(
+        given: 'owner viewing an already-liked gem',
+        whenever: 'the like button is tapped',
+        then: 'calls unlikeGem with the gem ID',
+        why: 'unliking a gem must persist the removal exactly once',
+      ),
+      (tester) async {
+        _setupSignedInUser(clients, _fakeRawOwnerChest);
+        _setupChest(clients, gemIDs: [_gemID], likedGemIDs: [_gemID]);
+
+        await tester.pumpChuckleChestApp(
+          clients: clients,
+          startAt: '/chest/collections/recently-added',
+        );
+
+        await tester.tap(find.byKey(_likeButtonKey));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => clients.gemClient.unlikeGem(gemID: _gemID),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      requirement(
+        given: 'a gem the user has liked',
+        whenever: 'navigating to the favourites collection',
+        then: 'shows that gem',
+        why: 'the favourites collection must display all liked gems',
+      ),
+      (tester) async {
+        _setupSignedInUser(clients, _fakeRawOwnerChest);
+        _setupChest(clients, gemIDs: [_gemID], likedGemIDs: [_gemID]);
+
+        await tester.pumpChuckleChestApp(
+          clients: clients,
+          startAt: '/chest/collections/favourites',
+        );
+
+        expect(find.byKey(_likeButtonKey), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      requirement(
+        given: 'viewer role viewing a gem',
+        whenever: 'the collection view is shown',
+        then: 'shows the like button but not the share button',
+        why: 'viewers can like gems but cannot share them',
+      ),
+      (tester) async {
+        _setupSignedInUser(clients, _fakeRawViewerChest);
+        _setupChest(clients, gemIDs: [_gemID]);
+
+        await tester.pumpChuckleChestApp(
+          clients: clients,
+          startAt: '/chest/collections/recently-added',
+        );
+
+        expect(find.byKey(_likeButtonKey), findsOneWidget);
+        expect(find.byIcon(Icons.share_rounded), findsNothing);
+      },
+    );
+  });
+}

--- a/packages/data/database_client/lib/src/exceptions/_exceptions.dart
+++ b/packages/data/database_client/lib/src/exceptions/_exceptions.dart
@@ -9,6 +9,8 @@ export 'gem_delete.dart';
 export 'gem_fetch.dart';
 export 'gem_fetch_from_share_token.dart';
 export 'gem_ids_fetch.dart';
+export 'gem_like_delete.dart';
+export 'gem_like_insert.dart';
 export 'gem_save.dart';
 export 'gem_share_link_insert.dart';
 export 'gem_years_fetch.dart';

--- a/packages/data/database_client/lib/src/exceptions/gem_like_delete.dart
+++ b/packages/data/database_client/lib/src/exceptions/gem_like_delete.dart
@@ -1,0 +1,12 @@
+// Parameters required for bobs jobs.
+// ignore_for_file: avoid_unused_constructor_parameters
+
+/// Represents an exception that occurs when deleting a gem like fails.
+enum CRawGemLikeDeleteException {
+  /// The failure was unitentifiable.
+  unknown;
+
+  factory CRawGemLikeDeleteException.fromError(Object error) {
+    return CRawGemLikeDeleteException.unknown;
+  }
+}

--- a/packages/data/database_client/lib/src/exceptions/gem_like_insert.dart
+++ b/packages/data/database_client/lib/src/exceptions/gem_like_insert.dart
@@ -1,0 +1,12 @@
+// Parameters required for bobs jobs.
+// ignore_for_file: avoid_unused_constructor_parameters
+
+/// Represents an exception that occurs when inserting a gem like fails.
+enum CRawGemLikeInsertException {
+  /// The failure was unitentifiable.
+  unknown;
+
+  factory CRawGemLikeInsertException.fromError(Object error) {
+    return CRawGemLikeInsertException.unknown;
+  }
+}

--- a/packages/data/database_client/lib/src/gem_client.dart
+++ b/packages/data/database_client/lib/src/gem_client.dart
@@ -15,6 +15,7 @@ class CGemClient {
     required this.gemsTable,
     required this.linesTable,
     required this.gemShareTokensTable,
+    required this.gemLikesTable,
     required this.supabaseClient,
   });
 
@@ -26,6 +27,9 @@ class CGemClient {
 
   /// The table that represents the `gem_share_tokens` table in the database.
   final CGemShareTokensTable gemShareTokensTable;
+
+  /// The table that represents the `gem_likes` table in the database.
+  final CGemLikesTable gemLikesTable;
 
   /// The supabase client.
   final SupabaseClient supabaseClient;
@@ -178,4 +182,43 @@ class CGemClient {
         ),
         onError: CRawGemShareTokenInsertException.fromError,
       );
+
+  /// Fetches the liked gem IDs for the given `chestID` from the database.
+  Task<List<String>, CRawGemIDsFetchException> fetchLikedGemIDs({
+    required String chestID,
+  }) => Task.attempt(
+    run: () => gemLikesTable.fetchValues(
+      column: CGemLikesTable.gemID,
+      filter: CGemLikesTable.chestID.equals(chestID),
+      modifier: gemLikesTable.order(CGemLikesTable.likedAt, ascending: false),
+    ),
+    handle: CRawGemIDsFetchException.fromError,
+  );
+
+  /// Likes the gem with the given `gemID` in the given `chestID`.
+  Task<String, CRawGemLikeInsertException> likeGem({
+    required String chestID,
+    required String gemID,
+  }) => Task.attempt(
+    run: () async {
+      await gemLikesTable.insert<void>(
+        inserts: [CGemLikesTableInsert(chestID: chestID, gemID: gemID)],
+      );
+      return gemID;
+    },
+    handle: CRawGemLikeInsertException.fromError,
+  );
+
+  /// Unlikes the gem with the given `gemID`.
+  Task<String, CRawGemLikeDeleteException> unlikeGem({
+    required String gemID,
+  }) => Task.attempt(
+    run: () async {
+      await gemLikesTable.delete<void>(
+        filter: CGemLikesTable.gemID.equals(gemID),
+      );
+      return gemID;
+    },
+    handle: CRawGemLikeDeleteException.fromError,
+  );
 }

--- a/packages/data/database_client/lib/src/tables/_tables.dart
+++ b/packages/data/database_client/lib/src/tables/_tables.dart
@@ -1,5 +1,6 @@
 export 'avatars.dart';
 export 'chests.dart';
+export 'gem_likes.dart';
 export 'gem_share_tokens.dart';
 export 'gems.dart';
 export 'invitations.dart';

--- a/packages/data/database_client/lib/src/tables/gem_likes.dart
+++ b/packages/data/database_client/lib/src/tables/gem_likes.dart
@@ -1,0 +1,32 @@
+import 'package:typesafe_supabase/typesafe_supabase.dart';
+
+part 'gem_likes.g.dart';
+
+/// {@template CGemLikesTable}
+///
+/// Represents the `gem_likes` table in the Supabase database.
+///
+/// {@endtemplate}
+@PgTableHere()
+class CGemLikesTable extends SupabaseTable<CGemLikesTable> {
+  /// {@macro CGemLikesTable}
+  CGemLikesTable(super.client)
+    : super(tableName: tableName, primaryKey: [gemID, userID]);
+
+  /// The name of the table in the Supabase database.
+  static const tableName = PgTableName<CGemLikesTable>('gem_likes');
+
+  /// The ID of the chest the gem belongs to.
+  static final chestID = PgStringColumn<CGemLikesTable>('chest_id');
+
+  /// The ID of the gem.
+  static final gemID = PgStringColumn<CGemLikesTable>('gem_id');
+
+  /// The ID of the user who liked the gem.
+  @PgColumnHasDefault()
+  static final userID = PgStringColumn<CGemLikesTable>('user_id');
+
+  /// The time the gem was liked.
+  @PgColumnHasDefault()
+  static final likedAt = PgUTCDateTimeColumn<CGemLikesTable>('liked_at');
+}

--- a/packages/data/database_client/lib/src/tables/gem_likes.g.dart
+++ b/packages/data/database_client/lib/src/tables/gem_likes.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'gem_likes.dart';
+
+// **************************************************************************
+// PgUpsertGenerator
+// **************************************************************************
+
+// Typedefs are self-documenting.
+// ignore_for_line: public_member_api_docs
+typedef CGemLikesTableInsert = CGemLikesTableUpsert;
+
+/// {@template CGemLikesTableUpsert}
+///
+/// Represents the data required to perform an insert or upsert operation on the
+/// [CGemLikesTable] table.
+///
+/// {@endtemplate}
+class CGemLikesTableUpsert extends PgUpsert<CGemLikesTable> {
+  /// {@macro CGemLikesTableUpsert}
+  CGemLikesTableUpsert({
+    required this.chestID,
+    required this.gemID,
+    this.likedAt,
+    this.userID,
+  }) : super([
+         CGemLikesTable.chestID(chestID),
+         CGemLikesTable.gemID(gemID),
+         if (likedAt != null) CGemLikesTable.likedAt(likedAt),
+         if (userID != null) CGemLikesTable.userID(userID),
+       ]);
+
+  final String chestID;
+  final String gemID;
+  final DateTime? likedAt;
+  final String? userID;
+}

--- a/packages/domain/gem_repository/lib/src/exceptions/_exceptions.dart
+++ b/packages/domain/gem_repository/lib/src/exceptions/_exceptions.dart
@@ -2,6 +2,8 @@ export 'gem_delete.dart';
 export 'gem_fetch.dart';
 export 'gem_fetch_from_share_token.dart';
 export 'gem_ids_fetch.dart';
+export 'gem_like_delete.dart';
+export 'gem_like_insert.dart';
 export 'gem_save.dart';
 export 'gem_share.dart';
 export 'gem_share_token_creation.dart';

--- a/packages/domain/gem_repository/lib/src/exceptions/gem_like_delete.dart
+++ b/packages/domain/gem_repository/lib/src/exceptions/gem_like_delete.dart
@@ -1,0 +1,14 @@
+import 'package:cdatabase_client/cdatabase_client.dart';
+
+/// Represents an exception that occurs when unliking a gem fails.
+enum CGemLikeDeleteException {
+  /// The failure was unitentifiable.
+  unknown;
+
+  /// Converts the raw exception to a [CGemLikeDeleteException].
+  static CGemLikeDeleteException fromRaw(CRawGemLikeDeleteException e) {
+    return switch (e) {
+      CRawGemLikeDeleteException.unknown => CGemLikeDeleteException.unknown,
+    };
+  }
+}

--- a/packages/domain/gem_repository/lib/src/exceptions/gem_like_insert.dart
+++ b/packages/domain/gem_repository/lib/src/exceptions/gem_like_insert.dart
@@ -1,0 +1,14 @@
+import 'package:cdatabase_client/cdatabase_client.dart';
+
+/// Represents an exception that occurs when liking a gem fails.
+enum CGemLikeInsertException {
+  /// The failure was unitentifiable.
+  unknown;
+
+  /// Converts the raw exception to a [CGemLikeInsertException].
+  static CGemLikeInsertException fromRaw(CRawGemLikeInsertException e) {
+    return switch (e) {
+      CRawGemLikeInsertException.unknown => CGemLikeInsertException.unknown,
+    };
+  }
+}

--- a/packages/domain/gem_repository/lib/src/gem_repository.dart
+++ b/packages/domain/gem_repository/lib/src/gem_repository.dart
@@ -135,4 +135,26 @@ class CGemRepository {
         onFailure: CGemShareTokenCreationException.fromRaw,
         onSuccess: (success) => success.token,
       );
+
+  /// Fetches the IDs of the liked gems in the chest with the given [chestID].
+  Task<List<String>, CGemIDsFetchException> fetchLikedGemIDs({
+    required String chestID,
+  }) => gemClient
+      .fetchLikedGemIDs(chestID: chestID)
+      .convertFailure(CGemIDsFetchException.fromRaw);
+
+  /// Likes the gem with the given [gemID] in the chest with the given
+  /// [chestID].
+  Task<String, CGemLikeInsertException> likeGem({
+    required String chestID,
+    required String gemID,
+  }) => gemClient
+      .likeGem(chestID: chestID, gemID: gemID)
+      .convertFailure(CGemLikeInsertException.fromRaw);
+
+  /// Unlikes the gem with the given [gemID].
+  Task<String, CGemLikeDeleteException> unlikeGem({required String gemID}) =>
+      gemClient.unlikeGem(gemID: gemID).convertFailure(
+        CGemLikeDeleteException.fromRaw,
+      );
 }

--- a/packages/domain/gem_repository/test/src/gem_repository_test.dart
+++ b/packages/domain/gem_repository/test/src/gem_repository_test.dart
@@ -548,5 +548,128 @@ void main() {
         },
       );
     });
+
+    group('fetchLikedGemIDs', () {
+      Task<List<String>, CRawGemIDsFetchException> mockFetch() =>
+          gemClient.fetchLikedGemIDs(chestID: any(named: 'chestID'));
+
+      Task<List<String>, CGemIDsFetchException> fetchTask() =>
+          repo.fetchLikedGemIDs(chestID: _chestID);
+
+      test(
+        requirement(
+          given: 'chest ID',
+          whenever: 'fetchLikedGemIDs succeeds',
+          then: 'returns liked gem IDs list',
+        ),
+        () async {
+          when(mockFetch).thenReturn(Task.succeed([_gemID]));
+
+          final result = await fetchTask().run();
+
+          expect(result.asSuccess, equals([_gemID]));
+        },
+      );
+
+      test(
+        requirement(
+          given: 'chest ID',
+          whenever: 'fetchLikedGemIDs fails for unknown reason',
+          then: 'returns [unknown] exception',
+        ),
+        () async {
+          when(
+            mockFetch,
+          ).thenReturn(Task.fail(CRawGemIDsFetchException.unknown));
+
+          final result = await fetchTask().run();
+
+          expect(result.asFailure, CGemIDsFetchException.unknown);
+        },
+      );
+    });
+
+    group('likeGem', () {
+      Task<String, CRawGemLikeInsertException> mockLikeGem() =>
+          gemClient.likeGem(
+            chestID: any(named: 'chestID'),
+            gemID: any(named: 'gemID'),
+          );
+
+      Task<String, CGemLikeInsertException> likeGemTask() =>
+          repo.likeGem(chestID: _chestID, gemID: _gemID);
+
+      test(
+        requirement(
+          given: 'chest ID and gem ID',
+          whenever: 'likeGem succeeds',
+          then: 'returns liked gem ID',
+        ),
+        () async {
+          when(mockLikeGem).thenReturn(Task.succeed(_gemID));
+
+          final result = await likeGemTask().run();
+
+          expect(result.asSuccess, _gemID);
+        },
+      );
+
+      test(
+        requirement(
+          given: 'chest ID and gem ID',
+          whenever: 'likeGem fails for unknown reason',
+          then: 'returns [unknown] exception',
+        ),
+        () async {
+          when(
+            mockLikeGem,
+          ).thenReturn(Task.fail(CRawGemLikeInsertException.unknown));
+
+          final result = await likeGemTask().run();
+
+          expect(result.asFailure, CGemLikeInsertException.unknown);
+        },
+      );
+    });
+
+    group('unlikeGem', () {
+      Task<String, CRawGemLikeDeleteException> mockUnlikeGem() =>
+          gemClient.unlikeGem(gemID: any(named: 'gemID'));
+
+      Task<String, CGemLikeDeleteException> unlikeGemTask() =>
+          repo.unlikeGem(gemID: _gemID);
+
+      test(
+        requirement(
+          given: 'gem ID',
+          whenever: 'unlikeGem succeeds',
+          then: 'returns unliked gem ID',
+        ),
+        () async {
+          when(mockUnlikeGem).thenReturn(Task.succeed(_gemID));
+
+          final result = await unlikeGemTask().run();
+
+          expect(result.asSuccess, _gemID);
+        },
+      );
+
+      test(
+        requirement(
+          given: 'gem ID',
+          whenever: 'unlikeGem fails for unknown reason',
+          then: 'returns [unknown] exception',
+        ),
+        () async {
+          when(
+            mockUnlikeGem,
+          ).thenReturn(Task.fail(CRawGemLikeDeleteException.unknown));
+
+          final result = await unlikeGemTask().run();
+
+          expect(result.asFailure, CGemLikeDeleteException.unknown);
+        },
+      );
+    });
   });
 }

--- a/supabase/migrations/20260703191319_add_gem_likes_public.sql
+++ b/supabase/migrations/20260703191319_add_gem_likes_public.sql
@@ -1,0 +1,5 @@
+alter type "public"."app_permission" add value if not exists 'gem_likes.insert';
+
+alter type "public"."app_permission" add value if not exists 'gem_likes.select';
+
+alter type "public"."app_permission" add value if not exists 'gem_likes.delete';

--- a/supabase/migrations/20260703191320_add_gem_likes_table.sql
+++ b/supabase/migrations/20260703191320_add_gem_likes_table.sql
@@ -1,0 +1,85 @@
+create table "public"."gem_likes" (
+    "chest_id" uuid not null,
+    "gem_id" uuid not null,
+    "user_id" uuid not null default auth.uid(),
+    "liked_at" timestamp with time zone not null default now()
+);
+
+
+alter table "public"."gem_likes" enable row level security;
+
+CREATE UNIQUE INDEX gem_likes_pkey ON public.gem_likes USING btree (gem_id, user_id);
+
+alter table "public"."gem_likes" add constraint "gem_likes_pkey" PRIMARY KEY using index "gem_likes_pkey";
+
+alter table "public"."gem_likes" add constraint "gem_likes_gem_id_fkey" FOREIGN KEY (gem_id) REFERENCES public.gems(id) ON UPDATE CASCADE ON DELETE CASCADE not valid;
+
+alter table "public"."gem_likes" validate constraint "gem_likes_gem_id_fkey";
+
+grant delete on table "public"."gem_likes" to "anon";
+
+grant insert on table "public"."gem_likes" to "anon";
+
+grant references on table "public"."gem_likes" to "anon";
+
+grant select on table "public"."gem_likes" to "anon";
+
+grant trigger on table "public"."gem_likes" to "anon";
+
+grant truncate on table "public"."gem_likes" to "anon";
+
+grant update on table "public"."gem_likes" to "anon";
+
+grant delete on table "public"."gem_likes" to "authenticated";
+
+grant insert on table "public"."gem_likes" to "authenticated";
+
+grant references on table "public"."gem_likes" to "authenticated";
+
+grant select on table "public"."gem_likes" to "authenticated";
+
+grant trigger on table "public"."gem_likes" to "authenticated";
+
+grant truncate on table "public"."gem_likes" to "authenticated";
+
+grant update on table "public"."gem_likes" to "authenticated";
+
+grant delete on table "public"."gem_likes" to "service_role";
+
+grant insert on table "public"."gem_likes" to "service_role";
+
+grant references on table "public"."gem_likes" to "service_role";
+
+grant select on table "public"."gem_likes" to "service_role";
+
+grant trigger on table "public"."gem_likes" to "service_role";
+
+grant truncate on table "public"."gem_likes" to "service_role";
+
+grant update on table "public"."gem_likes" to "service_role";
+
+
+  create policy "Allow authorized delete access"
+  on "public"."gem_likes"
+  as permissive
+  for delete
+  to authenticated
+using ((public.authorize('gem_likes.delete'::public.app_permission, chest_id) AND (user_id = auth.uid())));
+
+
+
+  create policy "Allow authorized insert access"
+  on "public"."gem_likes"
+  as permissive
+  for insert
+  to authenticated
+with check ((public.authorize('gem_likes.insert'::public.app_permission, chest_id) AND (user_id = auth.uid())));
+
+
+
+  create policy "Allow authorized select access"
+  on "public"."gem_likes"
+  as permissive
+  for select
+  to authenticated
+using ((public.authorize('gem_likes.select'::public.app_permission, chest_id) AND (user_id = auth.uid())));

--- a/supabase/schemas/public/pre.sql
+++ b/supabase/schemas/public/pre.sql
@@ -45,7 +45,10 @@ CREATE TYPE "public"."app_permission" AS enum(
     'collection_share_tokens.insert',
     'collection_share_tokens.select',
     'collection_share_tokens.update',
-    'collection_share_tokens.delete'
+    'collection_share_tokens.delete',
+    'gem_likes.insert',
+    'gem_likes.select',
+    'gem_likes.delete'
 );
 
 CREATE TYPE "public"."app_role" AS enum(

--- a/supabase/schemas/public/tables/gem_likes/constraints.sql
+++ b/supabase/schemas/public/tables/gem_likes/constraints.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ONLY "public"."gem_likes"
+    ADD CONSTRAINT "gem_likes_gem_id_fkey" FOREIGN KEY ("gem_id") REFERENCES "public"."gems"("id") ON UPDATE CASCADE ON DELETE CASCADE;

--- a/supabase/schemas/public/tables/gem_likes/permissions.sql
+++ b/supabase/schemas/public/tables/gem_likes/permissions.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "public"."gem_likes" OWNER TO "postgres";
+
+GRANT ALL ON TABLE "public"."gem_likes" TO "anon";
+
+GRANT ALL ON TABLE "public"."gem_likes" TO "authenticated";
+
+GRANT ALL ON TABLE "public"."gem_likes" TO "service_role";

--- a/supabase/schemas/public/tables/gem_likes/policies.sql
+++ b/supabase/schemas/public/tables/gem_likes/policies.sql
@@ -1,0 +1,13 @@
+CREATE POLICY "Allow authorized delete access" ON "public"."gem_likes" AS permissive
+    FOR DELETE TO authenticated
+        USING (authorize('gem_likes.delete'::app_permission, chest_id) AND user_id = auth.uid());
+
+CREATE POLICY "Allow authorized insert access" ON "public"."gem_likes" AS permissive
+    FOR INSERT TO authenticated
+        WITH CHECK (authorize('gem_likes.insert'::app_permission, chest_id) AND user_id = auth.uid());
+
+CREATE POLICY "Allow authorized select access" ON "public"."gem_likes" AS permissive
+    FOR SELECT TO authenticated
+        USING (authorize('gem_likes.select'::app_permission, chest_id) AND user_id = auth.uid());
+
+ALTER TABLE "public"."gem_likes" ENABLE ROW LEVEL SECURITY;

--- a/supabase/schemas/public/tables/gem_likes/table.sql
+++ b/supabase/schemas/public/tables/gem_likes/table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS "public"."gem_likes"(
+    "chest_id" "uuid" NOT NULL,
+    "gem_id" "uuid" NOT NULL,
+    "user_id" "uuid" NOT NULL DEFAULT auth.uid(),
+    "liked_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+ALTER TABLE ONLY "public"."gem_likes"
+    ADD CONSTRAINT "gem_likes_pkey" PRIMARY KEY ("gem_id", "user_id");

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -72,5 +72,14 @@ INSERT INTO role_permissions(ROLE, permission)
 ('owner', 'collection_share_tokens.select'),
 ('collaborator', 'collection_share_tokens.select'),
 ('owner', 'collection_share_tokens.delete'),
-('collaborator', 'collection_share_tokens.delete');
+('collaborator', 'collection_share_tokens.delete'),
+('owner', 'gem_likes.insert'),
+('collaborator', 'gem_likes.insert'),
+('viewer', 'gem_likes.insert'),
+('owner', 'gem_likes.select'),
+('collaborator', 'gem_likes.select'),
+('viewer', 'gem_likes.select'),
+('owner', 'gem_likes.delete'),
+('collaborator', 'gem_likes.delete'),
+('viewer', 'gem_likes.delete');
 

--- a/wiki/Database.md
+++ b/wiki/Database.md
@@ -81,8 +81,12 @@ Three roles exist per chest, defined as `app_role` enum:
 | Person avatars | CRUD  | CRUD         | R      |
 | Collections    | CRUD  | CRUD         | R      |
 | Share tokens   | CRD   | CRD          | —      |
+| Gem likes      | CRD*  | CRD*         | CRD*   |
 | Invitations    | CRUD  | —            | —      |
 | User roles     | RU    | —            | —      |
+
+\* Gem likes: users can only create/read/delete their own like — RLS policies
+also require `user_id = auth.uid()`.
 
 Note: owners cannot modify their own `user_roles` row (policy enforces
 `user_id <> auth.uid()`).


### PR DESCRIPTION
## Summary
- New `gem_likes` table (RLS-scoped per user, all roles incl. viewer can like)
- Like button in gem view bottom bar, filled/unfilled by state, never on shared-gem page
- New "Favourites" collection page to swipe liked gems

## Test plan
- [x] `hobnob db:reset` / `hobnob db:test`
- [x] `hobnob dart:test`
- [x] `hobnob dart:analyze`
- [x] Manual: owner like/unlike + persistence
- [x] Manual: viewer like button works, share button absent
- [x] Manual: shared-gem page has no bottom bar
- [x] Manual: Favourites tile + swipe