### PR TITLE
Fix shared gem fetch error

### DIFF
--- a/supabase/migrations/20260717170414_fix_fetch_gem_with_people_share_token_key.sql
+++ b/supabase/migrations/20260717170414_fix_fetch_gem_with_people_share_token_key.sql
@@ -1,3 +1,5 @@
+set check_function_bodies = off;
+
 CREATE OR REPLACE FUNCTION public.fetch_gem_with_people(gem_id_param uuid)
   RETURNS jsonb
   LANGUAGE plpgsql
@@ -40,4 +42,5 @@ BEGIN
   -- Combine gem_data, lines_data, and people_data into a single JSONB object
   RETURN jsonb_build_object('gem', jsonb_set(gem_data_var, '{lines}', lines_data_var, TRUE), 'people', people_data_var);
 END;
-$function$;
+$function$
+;

--- a/supabase/migrations/20260717170414_fix_fetch_gem_with_people_share_token_key.sql
+++ b/supabase/migrations/20260717170414_fix_fetch_gem_with_people_share_token_key.sql
@@ -40,7 +40,7 @@ BEGIN
       WHERE
         l.gem_id = gem_id_param);
   -- Combine gem_data, lines_data, and people_data into a single JSONB object
-  RETURN jsonb_build_object('gem', jsonb_set(gem_data_var, '{lines}', lines_data_var, TRUE), 'people', people_data_var);
+  RETURN jsonb_build_object('gem', jsonb_set(gem_data_var, '{lines}', coalesce(lines_data_var, '[]'::jsonb), TRUE), 'people', people_data_var);
 END;
 $function$
 ;

--- a/supabase/schemas/public/functions/fetch_gem_with_people.sql
+++ b/supabase/schemas/public/functions/fetch_gem_with_people.sql
@@ -38,6 +38,6 @@ BEGIN
       WHERE
         l.gem_id = gem_id_param);
   -- Combine gem_data, lines_data, and people_data into a single JSONB object
-  RETURN jsonb_build_object('gem', jsonb_set(gem_data_var, '{lines}', lines_data_var, TRUE), 'people', people_data_var);
+  RETURN jsonb_build_object('gem', jsonb_set(gem_data_var, '{lines}', coalesce(lines_data_var, '[]'::jsonb), TRUE), 'people', people_data_var);
 END;
 $function$;

--- a/supabase/tests/public/functions/fetch_gem_with_people.test.sql
+++ b/supabase/tests/public/functions/fetch_gem_with_people.test.sql
@@ -1,0 +1,98 @@
+BEGIN;
+SELECT no_plan();
+
+    -- Arrange (shared setup)
+    SELECT tests.create_chucklechest_user('owner');
+    SELECT tests.create_chest('owner') AS chest_id \gset
+
+    SELECT tests.authenticate_as_service_role();
+    INSERT INTO public.people (nickname, date_of_birth, chest_id)
+    VALUES ('Alice', '1990-01-01', :'chest_id')
+    RETURNING id AS person_id \gset
+
+SAVEPOINT arrange_all;
+
+
+    -- Arrange
+    SELECT tests.authenticate_as_service_role();
+    INSERT INTO public.gems (number, occurred_at, chest_id)
+    VALUES (1, '2024-06-15'::date, :'chest_id')
+    RETURNING id AS gem_id \gset
+
+    INSERT INTO public.lines (text, gem_id, chest_id, person_id)
+    VALUES ('Hello!', :'gem_id', :'chest_id', :person_id);
+
+    -- Act
+    SELECT public.fetch_gem_with_people(:'gem_id') AS result \gset
+
+    -- Assert
+    SELECT is(
+        (:'result'::jsonb -> 'gem' -> 'gem_share_tokens'),
+        'null'::jsonb,
+        'Given: gem with no share token. When: fetch_gem_with_people called. Then: gem_share_tokens key is present with a JSON null value (client model requires the key to exist).'
+    );
+
+    SELECT is(
+        jsonb_array_length(:'result'::jsonb -> 'gem' -> 'lines'),
+        1,
+        'Given: gem with one line. When: fetch_gem_with_people called. Then: lines array has 1 entry.'
+    );
+
+    SELECT is(
+        (:'result'::jsonb -> 'gem' -> 'lines' -> 0 ->> 'text'),
+        'Hello!',
+        'Given: gem with one line. When: fetch_gem_with_people called. Then: lines array contains the line text.'
+    );
+
+    SELECT is(
+        (:'result'::jsonb -> 'people' -> 0 ->> 'nickname'),
+        'Alice',
+        'Given: line assigned to a person. When: fetch_gem_with_people called. Then: people array contains that person.'
+    );
+
+
+ROLLBACK TO arrange_all;
+
+
+    -- Arrange
+    SELECT tests.authenticate_as_service_role();
+    INSERT INTO public.gems (number, occurred_at, chest_id)
+    VALUES (1, '2024-06-15'::date, :'chest_id')
+    RETURNING id AS gem_id \gset
+
+    INSERT INTO public.lines (text, gem_id, chest_id, person_id)
+    VALUES ('Just narration.', :'gem_id', :'chest_id', NULL);
+
+    -- Act
+    SELECT public.fetch_gem_with_people(:'gem_id') AS result \gset
+
+    -- Assert
+    SELECT is(
+        (:'result'::jsonb -> 'people'),
+        'null'::jsonb,
+        'Given: gem with no lines assigned to a person. When: fetch_gem_with_people called. Then: people is null.'
+    );
+
+
+ROLLBACK TO arrange_all;
+
+
+    -- Arrange
+    SELECT tests.authenticate_as_service_role();
+    INSERT INTO public.gems (number, occurred_at, chest_id)
+    VALUES (1, '2024-06-15'::date, :'chest_id')
+    RETURNING id AS gem_id \gset
+
+    -- Act
+    SELECT public.fetch_gem_with_people(:'gem_id') AS result \gset
+
+    -- Assert
+    SELECT is(
+        (:'result'::jsonb -> 'gem' ->> 'id')::uuid,
+        :'gem_id'::uuid,
+        'Given: gem with zero lines. When: fetch_gem_with_people called. Then: gem data is still returned (not nulled out).'
+    );
+
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary
- `fetch_gem_with_people` built the gem JSON without a `gem_share_tokens` key, which the client model requires to be present. Opening a shared gem link always failed with a snackbar/error icon.
- Sets that key to `null` in the SQL function.

## Test plan
- [ ] Run migration locally, open a shared gem link, confirm it loads